### PR TITLE
image.index.pull must include a by-digest spec

### DIFF
--- a/docs/multiarch.rst
+++ b/docs/multiarch.rst
@@ -1711,7 +1711,7 @@ index
 
     pull
         list of pull specifications (as strings); one must include a
-        tag, one may include a digest
+        tag, one must include a digest
 
     tags
         list of tags that were updated to point to this manifest list,


### PR DESCRIPTION
For the archive 'repositories' list, a by-digest spec is optional
because v2 support is optional. However, for the image.index we
know that v2 support is required in order to have an image index
or manifest list, so a by-digest spec is required in that case.

Signed-off-by: Tim Waugh <twaugh@redhat.com>