### PR TITLE
add some project links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # osbs-docs
-Documentation for OSBS Project
+[Documentation for OSBS Project](https://osbs.readthedocs.io/)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,7 +4,8 @@ OpenShift Build Service
 
 OSBS is a collection of tools, workflows and integration points that build and release layered container images.
 
-OSBS hooks into Koji_ with the help of the koji-containerbuild plugin, and
+OSBS hooks into Koji_ with the help of the `koji-containerbuild plugin
+<https://github.com/release-engineering/koji-containerbuild>`_, and
 uses `OpenShift builds <https://docs.openshift.org/latest/dev_guide/builds.html>`_ as Content Generators to produce layered images.
 
 .. _Koji: https://pagure.io/koji


### PR DESCRIPTION
Link GitHub users to the main page where readthedocs renders OSBS's documentation so this is easier to find. 

Link the main index page to the koji-containerbuild project so it's easier to find that as well.

~While we're here, koji-containerbuild contains multiple plugins, so pluralize that description.~