### PR TITLE
Fix broken link to Build Parameters documentation

### DIFF
--- a/docs/build_parameters.rst
+++ b/docs/build_parameters.rst
@@ -1,3 +1,5 @@
+.. _build_parameters:
+
 Build Parameters
 ================
 

--- a/docs/build_process.rst
+++ b/docs/build_process.rst
@@ -280,9 +280,7 @@ equal to 6. The existing osbs-client configuration **reactor_config_secret**
 is deprecated (for all arrangements).
 
 For more details on how the build system is configured as of
-Arrangement 6, consult the `Build Parameters`_ document.
-
-.. _`Build Parameters`: build_parameters
+Arrangement 6, consult the :ref:`build_parameters` document.
 
 
 Logging


### PR DESCRIPTION
This fixes the link to the Build Parameters page in https://osbs.readthedocs.io/en/latest/build_process.html#arrangement-version-6-reactor-config-map